### PR TITLE
mask Tpl also without vrange

### DIFF
--- a/src/serval.py
+++ b/src/serval.py
@@ -224,7 +224,7 @@ class Tpl:
           # interpolate unbroadened mask
           BK |= self.bk
 
-     self.msk = interp(wk, 1.*(BK>0))
+      self.msk = interp(wk, 1.*(BK>0))
 
    def __call__(self, w, der=0):
       return self.evalfunc(w, self.funcarg, der=der)

--- a/src/serval.py
+++ b/src/serval.py
@@ -195,9 +195,11 @@ class Tpl:
       self.funcarg = self.initfunc(self.wk, self.fk)
       self.evalfunc = evalfunc
 
-      BK = 0 * self.bk   # broadened flag map
+      BK = 1 * self.bk   # flag map for interpolation
       dvmin = np.diff(self.wk).min() * c
       if (bk is not None) and (vrange is not None) and (dvmin > 0):
+          # broaden flag map
+          BK = 0 * self.bk
           istart = int(np.floor(vrange[0] / dvmin))
           istop = int(np.ceil(vrange[1] / dvmin))
           for i in range(istart, istop):
@@ -219,11 +221,6 @@ class Tpl:
               gplot(np.exp(wk), bk, ',', np.exp(wk), BK)
               pause()
            
-      else:
-          # if vrange is None
-          # interpolate unbroadened mask
-          BK |= self.bk
-
       self.msk = interp(wk, 1.*(BK>0))
 
    def __call__(self, w, der=0):

--- a/src/serval.py
+++ b/src/serval.py
@@ -218,13 +218,13 @@ class Tpl:
           if 0:
               gplot(np.exp(wk), bk, ',', np.exp(wk), BK)
               pause()
-               
-          self.msk = interp(wk, 1.*(BK>0))
            
       else:
           # if vrange is None
           # interpolate unbroadened mask
-          self.msk = interp(wk, 1.*(self.bk>0))
+          BK |= self.bk
+
+     self.msk = interp(wk, 1.*(BK>0))
 
    def __call__(self, w, der=0):
       return self.evalfunc(w, self.funcarg, der=der)

--- a/src/serval.py
+++ b/src/serval.py
@@ -218,8 +218,13 @@ class Tpl:
           if 0:
               gplot(np.exp(wk), bk, ',', np.exp(wk), BK)
               pause()
-
-      self.msk = interp(wk, 1.*(BK>0))
+               
+          self.msk = interp(wk, 1.*(BK>0))
+           
+      else:
+          # if vrange is None
+          # interpolate unbroadened mask
+          self.msk = interp(wk, 1.*(self.bk>0))
 
    def __call__(self, w, der=0):
       return self.evalfunc(w, self.funcarg, der=der)

--- a/src/serval.py
+++ b/src/serval.py
@@ -220,7 +220,7 @@ class Tpl:
           if 0:
               gplot(np.exp(wk), bk, ',', np.exp(wk), BK)
               pause()
-           
+
       self.msk = interp(wk, 1.*(BK>0))
 
    def __call__(self, w, der=0):


### PR DESCRIPTION
- Tpl: if vrange is None, an unbroadened mask is returned instead of an empty mask