### PR TITLE
add: effective degrees of freedom for penalized csplines

### DIFF
--- a/src/cspline.py
+++ b/src/cspline.py
@@ -677,11 +677,9 @@ def ucbspl_fit(x, y=None, w=None, K=10, xmin=None, xmax=None, lam=0., pord=2, mu
             mod.xk, mod(), ' lt 1 pt 7,',
             x, y, mod(x), ' lt 3, "" us 1:3 w l lt 2')
 
-   if ic:
-         # computes AIC and BIC information criteria
+   if edf:
         # using the effective degrees of freedom
         # see Eilers & Marx (1996) Eq. (27)
-        
         if 0:
             # without band matrices -> slow
             
@@ -721,7 +719,7 @@ def ucbspl_fit(x, y=None, w=None, K=10, xmin=None, xmax=None, lam=0., pord=2, mu
 
 # compute effective degrees of freedom
 def loop_sum_edf(BTWB_lamDTDinv, G, kk, w):
-   """
+    """
     Compute effective degrees of freedom using a loop-based method to restrict memory usage.
 
     Parameters:

--- a/src/cspline.py
+++ b/src/cspline.py
@@ -555,39 +555,39 @@ def ucbspl_fit(x, y=None, w=None, K=10, xmin=None, xmax=None, lam=0., pord=2, mu
          BTy = BTy[1:K+1] * 1
          BTBbnd = BTBbnd[:,1:K+1] *1
 
-      if lam is not None:
+      if lam:
          # Add penalty lam*DTD
-         if isinstance(lam, float):
-             if pord == 0:
-                # diagonal
-                BTBbnd[0] += lam
-             elif pord == 1:
-                #  1  2 ...  2  2  1
-                # -1 -1 ... -1 -1
-                # diagonal
-                BTBbnd[0,[0,-1]] += lam
-                BTBbnd[0,1:-1] += 2*lam
-                # subdiagonals
-                BTBbnd[1,:-1] -= lam
-             elif pord == 2:
-                #   1  5  6 ...  6  5  1
-                #  -2 -4 -4 ... -4 -2
-                #   1  1  1 ...  1
-                # diagonal
-                BTBbnd[0,[0,-1]] += lam
-                BTBbnd[0,[1,-2]] += 5 * lam
-                BTBbnd[0,2:-2] += 6 * lam
-                # first subdiagonal
-                BTBbnd[1,[0,-2]] -= 2*lam
-                BTBbnd[1,1:-2] -= 4 * lam
-                # second subdiagonal
-                BTBbnd[2,:-2] += lam
-             else:
-                # generic version
-                D = np.diff(np.eye(nk), n=pord)
-                DTD = lam * np.dot(D,D.T)
-                for k in range(4):
-                   BTBbnd[k,:-k] += np.diag(DTD, k)
+         print(lam)
+         if pord == 0:
+            # diagonal
+            BTBbnd[0] += lam
+         elif pord == 1:
+            #  1  2 ...  2  2  1
+            # -1 -1 ... -1 -1
+            # diagonal
+            BTBbnd[0,[0,-1]] += lam
+            BTBbnd[0,1:-1] += 2*lam
+            # subdiagonals
+            BTBbnd[1,:-1] -= lam
+         elif pord == 2:
+            #   1  5  6 ...  6  5  1
+            #  -2 -4 -4 ... -4 -2
+            #   1  1  1 ...  1
+            # diagonal
+            BTBbnd[0,[0,-1]] += lam
+            BTBbnd[0,[1,-2]] += 5 * lam
+            BTBbnd[0,2:-2] += 6 * lam
+            # first subdiagonal
+            BTBbnd[1,[0,-2]] -= 2*lam
+            BTBbnd[1,1:-2] -= 4 * lam
+            # second subdiagonal
+            BTBbnd[2,:-2] += lam
+         else:
+            # generic version
+            D = np.diff(np.eye(nk), n=pord)
+            DTD = lam * np.dot(D,D.T)
+            for k in range(4):
+               BTBbnd[k,:-k] += np.diag(DTD, k)
 
    #ds9(BTBbnd)
    #pause()

--- a/src/cspline.py
+++ b/src/cspline.py
@@ -508,7 +508,7 @@ def ucbspl_fit(x, y=None, w=None, K=10, xmin=None, xmax=None, lam=0., pord=2, mu
    if nat:
       Gorg = 1 * G
       bk2bknat(G, kk, K)
-    
+
    nk = K + 2
    BTy = np.zeros(nk)
    BTBbnd = np.zeros((4, nk))
@@ -597,7 +597,7 @@ def ucbspl_fit(x, y=None, w=None, K=10, xmin=None, xmax=None, lam=0., pord=2, mu
       BTy += mu / e_mu**2
       BTBbnd[0] += 1. / e_mu**2
       
-   # copy band matrix since it gets overwritten below
+   # copy band matrix, since it gets overwritten below
    BTWB_lamDTDb = np.copy(BTBbnd)
    
    if cov:

--- a/src/cspline.py
+++ b/src/cspline.py
@@ -719,37 +719,37 @@ def ucbspl_fit(x, y=None, w=None, K=10, xmin=None, xmax=None, lam=0., pord=2, mu
 
 # compute effective degrees of freedom
 def loop_sum_edf(BTWB_lamDTDinv, G, kk, w):
-    """
-    Compute effective degrees of freedom using a loop-based method to restrict memory usage.
+   """
+   Compute effective degrees of freedom using a loop-based method to restrict memory usage.
 
-    Parameters:
-    -----------
-    BTWB_lamDTDinv : np.ndarray
-        A symmetric banded matrix (Nknot x Nknot).
-        
-    G : np.ndarray
-        A 2D array (4 x Ndat) representing transformed basis functions.
-        
-    kk : np.ndarray
-        A 1D array of indices defining the columns in G.
-        
-    w : np.ndarray
-        A 1D array of weights (size Ndat) for each column in G.
+   Parameters:
+   -----------
+   BTWB_lamDTDinv : np.ndarray
+      A symmetric banded matrix (Nknot x Nknot).
+      
+   G : np.ndarray
+      A 2D array (4 x Ndat) representing transformed basis functions.
+      
+   kk : np.ndarray
+      A 1D array of indices defining the columns in G.
+      
+   w : np.ndarray
+      A 1D array of weights (size Ndat) for each column in G.
 
-    Returns:
-    --------
-    float
-        Computed effective degrees of freedom.
-    """
-       
+   Returns:
+   --------
+   float
+      Computed effective degrees of freedom.
+   """
+         
    # get matrix dimensions
    Nknot = BTWB_lamDTDinv.shape[0]
    Ndat = G.shape[1]
-   
+
    # precompute for speed
    Gw = G * w[np.newaxis,:] 
    GTGw = G[np.newaxis,:,:] * Gw[:,np.newaxis,:]
-   
+
    # knot indices
    kn, ln = np.mgrid[:4,:4]
    kn = kn.ravel()

--- a/src/cspline.py
+++ b/src/cspline.py
@@ -733,7 +733,6 @@ def ucbspl_fit(x, y=None, w=None, K=10, xmin=None, xmax=None, lam=0., pord=2, mu
             
    return out
 
-
 # compute effective degrees of freedom
 def loop_sum_edf(BTWB_lamDTDinv, G, kk, w):
    """
@@ -742,16 +741,16 @@ def loop_sum_edf(BTWB_lamDTDinv, G, kk, w):
     Parameters:
     -----------
     BTWB_lamDTDinv : np.ndarray
-        A symmetric banded matrix (dim1 x dim1).
+        A symmetric banded matrix (Nknot x Nknot).
         
     G : np.ndarray
-        A 2D array (4 x dim2) representing transformed basis functions.
+        A 2D array (4 x Ndat) representing transformed basis functions.
         
     kk : np.ndarray
         A 1D array of indices defining the columns in G.
         
     w : np.ndarray
-        A 1D array of weights (size dim2) for each column in G.
+        A 1D array of weights (size Ndat) for each column in G.
 
     Returns:
     --------
@@ -775,11 +774,11 @@ def loop_sum_edf(BTWB_lamDTDinv, G, kk, w):
    for i in range(Ndat):
    # loop over each data points
       kki = kk[i]
-      if kki < dim1-4:
+      if kki < Nknot-4:
          edf += np.sum(BTWB_lamDTDinv[kki+kn, kki+ln] * GTGw[kn,ln,i])
       else:
          # need to check if elements are valid for the last elements of GTGw
-         valid = np.flatnonzero((kki+kn < dim1) & (kki+ln < dim1))
+         valid = np.flatnonzero((kki+kn < Nknot) & (kki+ln < Nknot))
          if valid.size > 0:
             # if elements are valid
             edf += np.sum(BTWB_lamDTDinv[kki+kn[valid], kki+ln[valid]] * GTGw[kn[valid],ln[valid],i])

--- a/src/cspline.py
+++ b/src/cspline.py
@@ -588,20 +588,6 @@ def ucbspl_fit(x, y=None, w=None, K=10, xmin=None, xmax=None, lam=0., pord=2, mu
                 DTD = lam * np.dot(D,D.T)
                 for k in range(4):
                    BTBbnd[k,:-k] += np.diag(DTD, k)
-                   
-         elif isinstance(lam, np.ndarray):
-             print('lambda is array')
-             if pord == 1:
-                #  1  2 ...  2  2  1
-                # -1 -1 ... -1 -1
-                # diagonal
-                BTBbnd[0,[0,-1]] += lam[[0,-2]]
-                BTBbnd[0,1:-1] += lam[0:-2]+lam[1:-1]
-                # subdiagonals
-                BTBbnd[1,:-1] -= lam[:-1]
-                   
-             else:
-                print('Not implemented.')
 
    #ds9(BTBbnd)
    #pause()


### PR DESCRIPTION
Adds option to compute the effective degrees of freedom. The effective degrees of freedom replace the classic degrees of freedom in the computation of the AIC and BIC information criteria for the pspline (Eilers & Marx, 1996). Computing the AIC or BIC allows to optimize the pspline penalty. 